### PR TITLE
tidy up partner logos

### DIFF
--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -647,3 +647,8 @@ dt {
   padding: 3px;
   font-size: 1.1rem;
 }
+
+.partner-logos-grid {
+  margin-top: 2em;
+  text-align: center;
+}

--- a/lib/views/help/partners.html.erb
+++ b/lib/views/help/partners.html.erb
@@ -39,19 +39,21 @@
 
 <h3>Freedom of Information Partners in Liberia.</h3>
 
-<%= link_to image_tag('ilab.png'), "http://ilabliberia.org/" %>
-<%= link_to image_tag('alab.png'), "http://accountabilitylab.org/" %>
-<%= link_to image_tag('cartercenter.png'), "http://www.cartercenter.org/countries/liberia.html" %>
-<%= link_to image_tag('cemesp.png'), "http://www.cemespliberia.org/" %>
-<%= link_to image_tag('cental.png'), "http://www.cental.org/" %>
-<%= image_tag('lficlogo.png') %>
-<%= link_to image_tag('LIWOMAC.png'), "http://liwomac.org/" %>
-<%= link_to image_tag('LMC-logo.png'), "https://www.facebook.com/Liberia-Media-Center-497490793629522/timeline/" %>
-<%= link_to image_tag('lmi_logo.png'), "http://www.lmdilr.org/" %>
-<%= link_to image_tag('micat.png'), "http://www.micatliberia.com/" %>
-<%= link_to image_tag('pul_logo.png'), "http://www.pul.org.lr/" %>
-<%= link_to image_tag('Sfcg-logo.png'), "https://www.sfcg.org/liberia/" %>
 
+<ul class=" partner-logos-grid small-block-grid-2 large-block-grid-3">
+    <li><%= link_to image_tag('ilab.png'), "http://ilabliberia.org/" %></li>
+    <li><%= link_to image_tag('alab.png'), "http://accountabilitylab.org/" %></li>
+    <li><%= link_to image_tag('cartercenter.png'), "http://www.cartercenter.org/countries/liberia.html" %></li>
+    <li><%= link_to image_tag('cemesp.png'), "http://www.cemespliberia.org/" %></li>
+    <li><%= link_to image_tag('cental.png'), "http://www.cental.org/" %></li>
+    <li><%= image_tag('lficlogo.png') %></li>
+    <li><%= link_to image_tag('LIWOMAC.png'), "http://liwomac.org/" %></li>
+    <li><%= link_to image_tag('LMC-logo.png'), "https://www.facebook.com/Liberia-Media-Center-497490793629522/timeline/" %></li>
+    <li><%= link_to image_tag('lmi_logo.png'), "http://www.lmdilr.org/" %></li>
+    <li><%= link_to image_tag('micat.png'), "http://www.micatliberia.com/" %></li>
+    <li><%= link_to image_tag('pul_logo.png'), "http://www.pul.org.lr/" %></li>
+    <li><%= link_to image_tag('Sfcg-logo.png'), "https://www.sfcg.org/liberia/" %></li>
+</ul>
 <div id="hash_link_padding"></div>
 
 </div>


### PR DESCRIPTION
This uses http://foundation.zurb.com/sites/docs/v/5.5.3/components/block_grid.html to arrange to partner logos in a more pleasing way
