### PR TITLE
Improve homepage layout on 500-900px screens

### DIFF
--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -673,6 +673,30 @@ dt {
 }
 
 /* Front page */
+
+// 50/50 split for frontpage columns at medium widths
+#frontpage_splash {
+  #left_column {
+    @include respond-min(32em){
+      @include grid-column(6);
+    }
+
+    @include respond-min( $main_menu-mobile_menu_cutoff ){
+      @include grid-column(8);
+    }
+  }
+
+  #right_column {
+    @include respond-min(32em){
+      @include grid-column(6);
+    }
+
+    @include respond-min( $main_menu-mobile_menu_cutoff ){
+      @include grid-column(4);
+    }
+  }
+}
+
 /* Drop the extract indentation on small screens */
 #frontpage_examples .excerpt {
     padding: 0.2em 0 0 0;


### PR DESCRIPTION
Fixes #45.

InfoLib currently runs Alaveteli 0.22.4, which has the old homepage layout. Eventually we should upgrade InfoLib to use the new homepage layout from Alaveteli 0.23.x, but in the meantime, here's a super quick fix for the current homepage when viewed on screens between 500–900px width.
# Before:

![screen shot 2016-04-14 at 17 36 19](https://cloud.githubusercontent.com/assets/739624/14535787/772d4d58-0267-11e6-9b30-de6306774295.png)
# After:

![screen shot 2016-04-14 at 17 32 22](https://cloud.githubusercontent.com/assets/739624/14535764/56532ea4-0267-11e6-92a5-c86a8833c122.png)
